### PR TITLE
Don't validate empty (null) value just return false

### DIFF
--- a/src/HCaptcha.php
+++ b/src/HCaptcha.php
@@ -112,7 +112,7 @@ class HCaptcha
     /**
      * Validate the user response.
      */
-    public function validate(string $token, ?string $remoteip = null): bool
+    public function validate(?string $token, ?string $remoteip = null): bool
     {
         if (empty($token)) {
             return false;

--- a/src/HCaptchaServiceProvider.php
+++ b/src/HCaptchaServiceProvider.php
@@ -16,7 +16,9 @@ class HCaptchaServiceProvider extends ServiceProvider
         ]);
 
         $this->app->validator->extend('hcaptcha', function ($attribute, $value) {
-            return $this->app->hcaptcha->validate($value, request()->ip());
+            return $value
+                ? $this->app->hcaptcha->validate($value, request()->ip())
+                : false;
         });
     }
 

--- a/src/HCaptchaServiceProvider.php
+++ b/src/HCaptchaServiceProvider.php
@@ -16,9 +16,7 @@ class HCaptchaServiceProvider extends ServiceProvider
         ]);
 
         $this->app->validator->extend('hcaptcha', function ($attribute, $value) {
-            return $value
-                ? $this->app->hcaptcha->validate($value, request()->ip())
-                : false;
+            return $this->app->hcaptcha->validate($value, request()->ip());
         });
     }
 


### PR DESCRIPTION
I noticed an issue when trying to submit a form without checking the hCaptcha button. It gave me this error:

```
Panfu\Laravel\HCaptcha\HCaptcha::validate(): Argument #1 ($token) must be of type string, null given
```

To fix it, I added a ternary operator that checks if the value is empty and returns false if it is. 

Let me know what you think!